### PR TITLE
Customize colors

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -1,58 +1,56 @@
-#### How to customize a colorscheme
+##### How to customize Dracula
 
-To override a highlight group, you will need to use the vim.api.nvim_set_hl()
-function.
-This function allows you to set the colors for a specific highlight group. 
-Here's an example of how to use this function to set the color of the 
-CursorLineNr highlight group to yellow:
+To override a highlight group, you will need to use the 
+vim.api.nvim_set_hl() function. 
+This function allows you to set the colors for a specific highlight group.
+Here's an example of how to use this function to set the color 
+of the CursorLineNr highlight group to yellow:
 
 ```lua
-local colors = require('dracula.palettes')
--- local colors = require('dracula.palettes.soft')
+local dracula = require 'dracula'
 
-vim.api.nvim_set_hl(0, 'CursorLineNr', { fg = colors.yellow })
+dracula.setup {
+ callback = function (colors)
+  vim.api.nvim_set_hl(0, 'CursorLineNr', { fg = colors.yellow })
+ end
+}
+
+vim.cmd 'colorscheme dracula'
 ```
 
 ![example1](https://user-images.githubusercontent.com/50273941/228698201-4a8a57fd-51e6-473a-aecd-4771cd07ad6f.png)
 
+#### How to customize Dracula colors
 
-In this example, we first load the dracula color palette into the colors variable. Then, we use vim.api.nvim_set_hl() 
-to set the color of the CursorLineNr highlight group to the value of colors.yellow.
-
-Another example, let's change the background and the float window background colors.
+In the previous example, we used the nvim_set_hl function 
+to change the CursorLineNr color. In this example, 
+we are overriding Dracula colors to change the background color:
 
 ```lua
-local colors = require('dracula.palettes')
--- local colors = require('dracula.palettes.soft')
+local dracula = require 'dracula'
 
-local custom_colors = {
-    bg = '#283630', -- similar to dracula pro bg color but not the same
-    float_bg = '#202b26',
+dracula.setup {
+ colors = {
+  bg = '#283630',
+  float_bg = '#202b26',
+ }
 }
 
-vim.api.nvim_set_hl(0, 'Normal', { fg = colors.fg, bg = custom_colors.bg })
-
--- we need to change linenr,cusorlinenr, signcolumn to match the background
-vim.api.nvim_set_hl(0, 'LineNr', { fg = colors.comment, bg = custom_colors.bg })
-vim.api.nvim_set_hl(0, 'CursorLineNr', { fg = colors.yellow, bg = custom_colors.bg })
-vim.api.nvim_set_hl(0, 'SignColumn', { fg = 'NONE', bg = custom_colors.bg })
-
--- now let's change the float window background colors
-vim.api.nvim_set_hl(0, 'NormalFloat', { fg = colors.fg, bg = custom_colors.float_bg })
-
--- of course, we need to change the WinSeparator background color to match the NormalFloat bg
-vim.api.nvim_set_hl(0, 'WinSeparator', { fg = colors.comment, bg = custom_colors.float_bg })
+vim.cmd 'colorscheme dracula'
 ```
+
 ![example2](https://user-images.githubusercontent.com/50273941/228698426-6acd98f2-bc11-45a7-b217-744389265730.png)
+
+#### Customize colors
 
 #### How to find a Highlight group
 
 To find a highlight group that you want to customize, you can use the `:Inspect command`.
-This command shows the current highlight 
+This command shows the current highlight
 groups being applied to the code in the current buffer. Here's how to use it:
 
-Alternatively, you can use plugins like [Telescope](https://github.com/nvim-telescope/telescope.nvim) or 
-[Playground](https://github.com/nvim-treesitter/playground) to find the highlight groups you need to customize your colorscheme. 
-For example, you can use the `:Telescope highlights` command with the Telescope 
-plugin to list all the available highlight 
+Alternatively, you can use plugins like [Telescope](https://github.com/nvim-telescope/telescope.nvim) or
+[Playground](https://github.com/nvim-treesitter/playground) to find the highlight groups you need to customize your colorscheme.
+For example, you can use the `:Telescope highlights` command with the Telescope
+plugin to list all the available highlight
 groups and select the one you want to customize.

--- a/dracula.toml
+++ b/dracula.toml
@@ -494,3 +494,7 @@
  HopNextKey = 'pink - b'
  HopNextKey1 = 'cyan - b'
  HopUnmatched = 'comment'
+
+[Lazy]
+ LazyH1 = 'purple blended_purple'
+ LazyButtonActive = 'link:LazyH1'

--- a/lua/dracula/config.lua
+++ b/lua/dracula/config.lua
@@ -6,6 +6,7 @@ function M:new()
 		transparent = false,
 		colors = {},
 		user_config = {},
+		callback = function() end,
 	}
 
 	setmetatable(config, self)
@@ -54,6 +55,12 @@ function M:set_transparent(transparent)
 	end
 
 	self.transparent = false
+end
+
+function M:set_callback(cb)
+	if type(cb) == "function" then
+		self.callback = cb
+	end
 end
 
 return M

--- a/lua/dracula/config.lua
+++ b/lua/dracula/config.lua
@@ -6,7 +6,7 @@ function M:new()
 		transparent = false,
 		colors = {},
 		user_config = {},
-		callback = function() end,
+		callback = function(colors) end,
 	}
 
 	setmetatable(config, self)

--- a/lua/dracula/config.lua
+++ b/lua/dracula/config.lua
@@ -1,0 +1,59 @@
+local M = {}
+
+function M:new()
+	local config = {
+		soft = false,
+		transparent = false,
+		colors = {},
+		user_config = {},
+	}
+
+	setmetatable(config, self)
+	self.__index = self
+
+	return config
+end
+
+function M:set_colors()
+	if self.soft then
+		self.colors = require("dracula.palettes.soft")
+		return
+	end
+
+	self.colors = require("dracula.palettes")
+end
+
+function M:set_user_colors()
+	if self.user_config.colors then
+		if vim.tbl_isempty(self.colors) then
+			return
+		end
+
+		if type(self.user_config.colors) == "table" then
+			self.colors = vim.tbl_extend("force", self.colors, self.user_config.colors)
+			return
+		end
+
+		self.colors = vim.tbl_extend("force", self.colors, self.user_config.colors(self.colors))
+	end
+end
+
+function M:set_soft(soft)
+	if soft then
+		self.soft = true
+		return
+	end
+
+	self.soft = false
+end
+
+function M:set_transparent(transparent)
+	if transparent then
+		self.transparent = true
+		return
+	end
+
+	self.transparent = false
+end
+
+return M

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -33,14 +33,15 @@ M.setup = function(user_config)
 
 	if vim.tbl_isempty(M.user_config) then
 		M.user_config = user_config
-	else
-		M:set_soft(M.user_config.soft)
-		M:set_transparent(M.user_config.transparent)
-    M:set_colors()
-    M:set_user_colors()
 	end
 
+	M:set_soft(M.user_config.soft)
+	M:set_transparent(M.user_config.transparent)
+	M:set_colors()
+	M:set_user_colors()
+
 	theme.set_highlights(M.colors)
+  M:apply_transparency()
 end
 
 return M

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -1,36 +1,19 @@
-local M = {}
 require("dracula.autocmd")
-local colors = require("dracula.palettes")
-local soft_colors = require("dracula.palettes.soft")
 local theme = require("dracula.theme")
+local Config = require("dracula.config")
+local M = Config:new()
 
-M.config = {}
-
-M.set_config = function(config)
-	if vim.tbl_isempty(M.config) then
-		if not config then
-			return
-		end
-
-		if config.soft then
-			M.config.soft = config.soft
-		end
-
-		if config.transparent then
-			M.config.transparent = config.transparent
-		end
-	end
-end
-
-M.set_transparent = function(c)
+function M:apply_transparency()
 	local hl = vim.api.nvim_set_hl
+	local c = self.colors
 
-	if M.config.transparent == true then
-		hl(0, "Normal", { fg = c.fg, bg = "NONE" })
-	end
+	hl(0, "Normal", { fg = c.fg, bg = "NONE" })
+	hl(0, "SignColumn", { fg = "NONE", bg = "NONE" })
+	hl(0, "CursorLineNr", { fg = c.pink, bg = "NONE" })
+	hl(0, "LineNr", { fg = c.comment, bg = "NONE" })
 end
 
-M.setup = function(config)
+function M.load_default()
 	if vim.g.colors_name then
 		vim.cmd("hi clear")
 	end
@@ -42,18 +25,22 @@ M.setup = function(config)
 
 	vim.o.termguicolors = true
 	vim.g.colors_name = "dracula"
+end
 
-	M.set_config(config)
+M.setup = function(user_config)
+	M.load_default()
+	user_config = user_config or {}
 
-	if M.config and M.config.soft then
-		theme.set_highlights(soft_colors)
-		M.set_transparent(soft_colors)
-
-		return
+	if vim.tbl_isempty(M.user_config) then
+		M.user_config = user_config
+	else
+		M:set_soft(M.user_config.soft)
+		M:set_transparent(M.user_config.transparent)
+    M:set_colors()
+    M:set_user_colors()
 	end
 
-	theme.set_highlights(colors)
-	M.set_transparent(colors)
+	theme.set_highlights(M.colors)
 end
 
 return M

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -43,7 +43,7 @@ M.setup = function(user_config)
 
 	theme.set_highlights(M.colors)
   M:apply_transparency()
-  M.callback()
+  M.callback(M.colors)
 end
 
 return M

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -4,13 +4,15 @@ local Config = require("dracula.config")
 local M = Config:new()
 
 function M:apply_transparency()
-	local hl = vim.api.nvim_set_hl
-	local c = self.colors
+	if self.transparent then
+		local hl = vim.api.nvim_set_hl
+		local c = self.colors
 
-	hl(0, "Normal", { fg = c.fg, bg = "NONE" })
-	hl(0, "SignColumn", { fg = "NONE", bg = "NONE" })
-	hl(0, "CursorLineNr", { fg = c.pink, bg = "NONE" })
-	hl(0, "LineNr", { fg = c.comment, bg = "NONE" })
+		hl(0, "Normal", { fg = c.fg, bg = "NONE" })
+		hl(0, "SignColumn", { fg = "NONE", bg = "NONE" })
+		hl(0, "CursorLineNr", { fg = c.pink, bg = "NONE" })
+		hl(0, "LineNr", { fg = c.comment, bg = "NONE" })
+	end
 end
 
 function M.load_default()
@@ -37,13 +39,13 @@ M.setup = function(user_config)
 
 	M:set_soft(M.user_config.soft)
 	M:set_transparent(M.user_config.transparent)
-  M:set_callback(M.user_config.callback)
+	M:set_callback(M.user_config.callback)
 	M:set_colors()
 	M:set_user_colors()
 
 	theme.set_highlights(M.colors)
-  M:apply_transparency()
-  M.callback(M.colors)
+	M:apply_transparency()
+	M.callback(M.colors)
 end
 
 return M

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -37,11 +37,13 @@ M.setup = function(user_config)
 
 	M:set_soft(M.user_config.soft)
 	M:set_transparent(M.user_config.transparent)
+  M:set_callback(M.user_config.callback)
 	M:set_colors()
 	M:set_user_colors()
 
 	theme.set_highlights(M.colors)
   M:apply_transparency()
+  M.callback()
 end
 
 return M

--- a/lua/dracula/theme.lua
+++ b/lua/dracula/theme.lua
@@ -464,6 +464,10 @@ theme.set_highlights = function(c)
   hl(0, "HopNextKey", { fg = c.pink, bg = 'NONE', bold=true, })
   hl(0, "HopNextKey1", { fg = c.cyan, bg = 'NONE', bold=true, })
   hl(0, "HopUnmatched", { fg = c.comment, bg = 'NONE' })
+
+  -- Lazy
+  hl(0, "LazyH1", { fg = c.purple, bg = c.blended_purple })
+  hl(0, "LazyButtonActive", { link = 'LazyH1' })
 end
 
 return theme


### PR DESCRIPTION
Users can customize the colors of Dracula by overriding its default color values, or add new ones.

Additionally, users can also customize the highlight groups of Dracula by using the vim.api.nvim_set_hl() function inside a callback function. 

